### PR TITLE
Handle unexpected errors with decorator

### DIFF
--- a/coalaip_bigchaindb/plugin.py
+++ b/coalaip_bigchaindb/plugin.py
@@ -66,8 +66,8 @@ class Plugin(AbstractPlugin):
 
         Raises:
             :exc:`coalaip.exceptions.EntityNotFoundError`: If no
-                transaction whose 'uuid' matches 'persist_id' could be
-                found in the connected BigchainDB instance
+                transaction whose 'uuid' matches :attr:`persist_id`
+                could be found in the connected BigchainDB instance
             :exc:`~.PersistenceError`: If any other unhandled error
                 from the BigchainDB driver occurred.
         """
@@ -133,8 +133,8 @@ class Plugin(AbstractPlugin):
 
         Raises:
             :exc:`coalaip.exceptions.EntityNotFoundError`: If no
-                transaction whose 'uuid' matches 'persist_id' could be
-                found in the connected BigchainDB instance
+                transaction whose 'uuid' matches :attr:`persist_id`
+                could be found in the connected BigchainDB instance
             :exc:`~.PersistenceError`: If any other unhandled error
                 from the BigchainDB driver occurred.
         """

--- a/coalaip_bigchaindb/utils.py
+++ b/coalaip_bigchaindb/utils.py
@@ -1,0 +1,23 @@
+from coalaip.exceptions import PersistenceError
+
+
+def reraise_as_persistence_error_if_not(*allowed_exceptions):
+    """Decorator: Reraises any exception from the wrapped function
+    by wrapping it around a :exc:`coalaip.PersistenceError` unless it's
+    one of the given :attr:`allowed_exceptions`.
+
+    Args:
+        *allowed_exceptions (:exc:`Exception`): Exceptions to not
+            reraise with :exc:`coalaip.PersistenceError`
+    """
+    def decorator(func):
+        def reraises_if_not(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except Exception as ex:
+                if not isinstance(ex, allowed_exceptions):
+                    raise PersistenceError(error=ex)
+                else:
+                    raise
+        return reraises_if_not
+    return decorator

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -103,9 +103,23 @@ def rights_assignment_model_json():
 
 
 @fixture
-def persisted_manifestation(bdb_driver, manifestation_model_jsonld,
-                            alice_keypair):
+def created_manifestation(bdb_driver, manifestation_model_jsonld,
+                          alice_keypair):
     return bdb_driver.transactions.create(
         manifestation_model_jsonld,
         verifying_key=alice_keypair['verifying_key'],
         signing_key=alice_keypair['signing_key'])
+
+
+@fixture
+def persisted_manifestation(bdb_driver, created_manifestation):
+    from tests.utils import bdb_transaction_test, poll_result
+    created_id = created_manifestation['id']
+
+    # Poll BigchainDB until the created manifestation becomes valid (and
+    # 'persisted')
+    poll_result(
+        lambda: bdb_driver.transactions.status(created_id),
+        lambda result: bdb_transaction_test)
+
+    return created_manifestation

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -67,9 +67,8 @@ def test_save_raises_persistence_error_on_error(monkeypatch, plugin,
         plugin.save(manifestation_model_json, user=alice_keypair)
 
 
-def test_get_persisted_model_status(plugin, bdb_driver,
-                                    persisted_manifestation):
-    tx_id = persisted_manifestation['id']
+def test_get_status(plugin, created_manifestation):
+    tx_id = created_manifestation['id']
 
     # Poll BigchainDB for the initial status
     poll_result(
@@ -86,7 +85,7 @@ def test_get_persisted_model_status(plugin, bdb_driver,
 
 
 def test_get_status_raises_not_found_error_on_not_found(monkeypatch, plugin,
-                                                        persisted_manifestation):
+                                                        created_manifestation):
     from bigchaindb_driver.exceptions import NotFoundError
     from coalaip.exceptions import EntityNotFoundError
 
@@ -96,11 +95,11 @@ def test_get_status_raises_not_found_error_on_not_found(monkeypatch, plugin,
                         mock_driver_not_found_error)
 
     with raises(EntityNotFoundError):
-        plugin.get_status(persisted_manifestation['id'])
+        plugin.get_status(created_manifestation['id'])
 
 
 def test_get_status_raises_persistence_error_on_error(monkeypatch, plugin,
-                                                      persisted_manifestation):
+                                                      created_manifestation):
     from coalaip.exceptions import PersistenceError
 
     def mock_driver_not_found_error(*args, **kwargs):
@@ -109,23 +108,17 @@ def test_get_status_raises_persistence_error_on_error(monkeypatch, plugin,
                         mock_driver_not_found_error)
 
     with raises(PersistenceError):
-        plugin.get_status(persisted_manifestation['id'])
+        plugin.get_status(created_manifestation['id'])
 
 
-def test_load_model(plugin, bdb_driver, persisted_manifestation):
+def test_load_model(plugin, persisted_manifestation):
     tx_id = persisted_manifestation['id']
-
-    # Poll BigchainDB until the persisted manifestation becomes valid
-    poll_result(
-        lambda: plugin.get_status(tx_id),
-        lambda result: bdb_transaction_test)
-
     loaded_transaction = plugin.load(tx_id)
     assert loaded_transaction == persisted_manifestation['transaction']['data']['payload']
 
 
 def test_load_model_raises_not_found_error_on_not_found(
-        monkeypatch, plugin, bdb_driver, persisted_manifestation):
+        monkeypatch, plugin, created_manifestation):
     from bigchaindb_driver.exceptions import NotFoundError
     from coalaip.exceptions import EntityNotFoundError
 
@@ -135,12 +128,11 @@ def test_load_model_raises_not_found_error_on_not_found(
                         mock_driver_not_found_error)
 
     with raises(EntityNotFoundError):
-        plugin.load(persisted_manifestation['id'])
+        plugin.load(created_manifestation['id'])
 
 
 def test_load_model_raises_persistence_error_on_error(monkeypatch, plugin,
-                                                      bdb_driver,
-                                                      persisted_manifestation):
+                                                      created_manifestation):
     from coalaip.exceptions import PersistenceError
 
     def mock_driver_not_found_error(*args, **kwargs):
@@ -149,7 +141,7 @@ def test_load_model_raises_persistence_error_on_error(monkeypatch, plugin,
                         mock_driver_not_found_error)
 
     with raises(PersistenceError):
-        plugin.load(persisted_manifestation['id'])
+        plugin.load(created_manifestation['id'])
 
 
 @mark.skip(reason='transfer() not implemented yet')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,30 @@
+from pytest import raises
+
+
+def test_reraise_as_persistence_error():
+    from coalaip.exceptions import PersistenceError
+    from coalaip_bigchaindb.utils import reraise_as_persistence_error_if_not
+    mock_type_error = TypeError()
+
+    @reraise_as_persistence_error_if_not(ValueError)
+    def raises_type_error():
+        raise mock_type_error
+
+    # Raises PersistenceError with the TypeError inside of it
+    with raises(PersistenceError) as excinfo:
+        raises_type_error()
+    assert excinfo.value.error == mock_type_error
+
+
+def test_reraise_as_persistence_error_raises_allowed():
+    from coalaip_bigchaindb.utils import reraise_as_persistence_error_if_not
+    mock_type_error = TypeError()
+
+    @reraise_as_persistence_error_if_not(TypeError)
+    def raises_type_error():
+        raise mock_type_error
+
+    # Raises the allowed TypeError
+    with raises(TypeError) as excinfo:
+        raises_type_error()
+    assert excinfo.value == mock_type_error


### PR DESCRIPTION
Adds a decorator to reraise unexpected exceptions as `PersistenceError`s rather than sprinkling it around the code.