### PR TITLE
Implement Entity transfers

### DIFF
--- a/coalaip_bigchaindb/plugin.py
+++ b/coalaip_bigchaindb/plugin.py
@@ -169,16 +169,16 @@ class Plugin(AbstractPlugin):
                 signers=user['public_key'],
                 asset={'data': entity_data})
         except BigchaindbException as ex:
-            raise EntityCreationError(error=ex)
+            raise EntityCreationError(error=ex) from ex
         try:
             fulfilled_tx = self.driver.transactions.fulfill(
                 tx, private_keys=user['private_key'])
         except MissingPrivateKeyError as ex:
-            raise EntityCreationError(error=ex)
+            raise EntityCreationError(error=ex) from ex
         try:
             self.driver.transactions.send(fulfilled_tx)
         except (TransportError, ConnectionError) as ex:
-            raise EntityCreationError(error=ex)
+            raise EntityCreationError(error=ex) from ex
 
         return fulfilled_tx['id']
 

--- a/coalaip_bigchaindb/plugin.py
+++ b/coalaip_bigchaindb/plugin.py
@@ -210,7 +210,8 @@ class Plugin(AbstractPlugin):
 
     @reraise_as_persistence_error_if_not(EntityNotFoundError,
                                          EntityTransferError)
-    def transfer(self, persist_id, transfer_payload, *, from_user, to_user):
+    def transfer(self, persist_id, transfer_payload=None, *, from_user,
+                 to_user):
         """Transfer the entity whose creation transaction matches
         :attr:`persist_id` from the current owner (:attr:`from_user`) to
         a new owner (:attr:`to_user`).
@@ -218,8 +219,8 @@ class Plugin(AbstractPlugin):
         Args:
             persist_id (str): Id of the creation transaction for the
                 entity on the connected BigchainDB instance
-            transfer_payload (dict): A dict holding the transfer's
-                payload
+            transfer_payload (dict, optional): A dict holding the
+                transfer's payload
             from_user (dict, keyword): A dict holding the current
                 owner's public key and private key (see
                 :meth:`generate_user`)

--- a/coalaip_bigchaindb/utils.py
+++ b/coalaip_bigchaindb/utils.py
@@ -1,3 +1,4 @@
+from functools import wraps
 from coalaip.exceptions import PersistenceError
 
 
@@ -11,6 +12,7 @@ def reraise_as_persistence_error_if_not(*allowed_exceptions):
             reraise with :exc:`coalaip.PersistenceError`
     """
     def decorator(func):
+        @wraps(func)
         def reraises_if_not(*args, **kwargs):
             try:
                 return func(*args, **kwargs)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2,7 +2,6 @@
 
 from pytest import mark, raises
 from tests.utils import (
-    make_transfer_tx,
     poll_bdb_transaction,
     poll_bdb_transaction_valid,
     poll_result,
@@ -26,6 +25,8 @@ def test_generate_user(plugin):
 
 def test_get_history(plugin, bdb_driver, alice_keypair, bob_keypair,
                      persisted_manifestation):
+    from coalaip_bigchaindb.utils import make_transfer_tx
+
     # Transfer to Bob
     transfer_to_bob_tx = make_transfer_tx(bdb_driver,
                                           input_tx=persisted_manifestation,

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -103,31 +103,6 @@ def test_load_model(plugin, persisted_manifestation):
     assert loaded_transaction == persisted_manifestation['asset']['data']
 
 
-def test_load_model_raises_not_found_error_on_not_found(
-        monkeypatch, plugin, created_manifestation):
-    from bigchaindb_driver.exceptions import NotFoundError
-    from coalaip.exceptions import EntityNotFoundError
-
-    def mock_driver_not_found_error(*args, **kwargs):
-        raise NotFoundError()
-    monkeypatch.setattr(plugin.driver.transactions, 'retrieve',
-                        mock_driver_not_found_error)
-
-    with raises(EntityNotFoundError):
-        plugin.load(created_manifestation['id'])
-
-
-def test_load_model_raises_persistence_error_on_error(monkeypatch, plugin,
-                                                      created_manifestation):
-    from coalaip.exceptions import PersistenceError
-
-    def mock_driver_error(*args, **kwargs):
-        raise Exception()
-    monkeypatch.setattr(plugin.driver.transactions, 'retrieve',
-                        mock_driver_error)
-
-    with raises(PersistenceError):
-        plugin.load(created_manifestation['id'])
 
 
 @mark.parametrize('model_name', [
@@ -305,10 +280,10 @@ def test_generic_plugin_func_on_id_raises_not_found_error_on_not_found(
 
 def test_transfer_raises_not_found_error_on_not_found(
         monkeypatch, plugin, alice_keypair, bob_keypair,
-        created_manifestation):
+        created_manifestation_id):
     from bigchaindb_driver.exceptions import NotFoundError
     from coalaip.exceptions import EntityNotFoundError
-    tx_id = created_manifestation['id']
+    tx_id = created_manifestation_id
 
     def mock_driver_not_found_error(*args, **kwargs):
         raise NotFoundError()

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -103,6 +103,11 @@ def test_load_model(plugin, persisted_manifestation):
     assert loaded_transaction == persisted_manifestation['asset']['data']
 
 
+def test_load_transfer_rights_assignment_model(
+        plugin, transferred_manifestation_tx):
+    tx_id = transferred_manifestation_tx['id']
+    loaded_rights_assignment = plugin.load(tx_id)
+    assert loaded_rights_assignment == transferred_manifestation_tx['metadata']
 
 
 @mark.parametrize('model_name', [

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,21 @@
 from pytest import raises
-from tests.utils import make_transfer_tx
+
+
+def test_make_transfer_transaction(bdb_driver, alice_keypair, bob_keypair,
+                                   created_manifestation):
+    from coalaip_bigchaindb.utils import make_transfer_tx
+    mock_metadata = {'mock': 'mock'}
+    transfer_tx = make_transfer_tx(bdb_driver, input_tx=created_manifestation,
+                                   recipients=bob_keypair['public_key'],
+                                   metadata=mock_metadata)
+    transfer_tx = bdb_driver.transactions.fulfill(
+        transfer_tx, private_keys=alice_keypair['private_key'])
+
+    assert transfer_tx['asset']['id'] == created_manifestation['id']
+    assert transfer_tx['metadata'] == mock_metadata
+    assert transfer_tx['inputs'][0]['fulfills']['txid'] == created_manifestation['id']
+    assert transfer_tx['inputs'][0]['owners_before'][0] == alice_keypair['public_key']
+    assert transfer_tx['outputs'][0]['public_keys'][0] == bob_keypair['public_key']
 
 
 def test_reraise_as_persistence_error():
@@ -33,7 +49,7 @@ def test_reraise_as_persistence_error_raises_allowed():
 
 def test_order_transactions(bdb_driver, alice_keypair, bob_keypair):
     import random
-    from coalaip_bigchaindb.utils import order_transactions
+    from coalaip_bigchaindb.utils import make_transfer_tx, order_transactions
     create_tx = bdb_driver.transactions.prepare(
         operation='CREATE',
         signers=alice_keypair['public_key'])
@@ -51,7 +67,7 @@ def test_order_transactions(bdb_driver, alice_keypair, bob_keypair):
 def test_order_transactions_is_correct_without_create(
         bdb_driver, alice_keypair, bob_keypair):
     import random
-    from coalaip_bigchaindb.utils import order_transactions
+    from coalaip_bigchaindb.utils import make_transfer_tx, order_transactions
     create_tx = bdb_driver.transactions.prepare(
         operation='CREATE',
         signers=alice_keypair['public_key'])
@@ -76,7 +92,7 @@ def test_order_empty_transations():
 
 def test_order_transactions_fails_with_multiple_endings(
         bdb_driver, alice_keypair, bob_keypair, carly_keypair):
-    from coalaip_bigchaindb.utils import order_transactions
+    from coalaip_bigchaindb.utils import make_transfer_tx, order_transactions
     create_tx = bdb_driver.transactions.prepare(
         operation='CREATE',
         signers=alice_keypair['public_key'])
@@ -93,7 +109,7 @@ def test_order_transactions_fails_with_multiple_endings(
 
 def test_order_transactions_fails_with_cyclic_tx(
         bdb_driver, alice_keypair, bob_keypair, carly_keypair):
-    from coalaip_bigchaindb.utils import order_transactions
+    from coalaip_bigchaindb.utils import make_transfer_tx, order_transactions
     create_tx = bdb_driver.transactions.prepare(
         operation='CREATE',
         signers=alice_keypair['public_key'])
@@ -120,7 +136,7 @@ def test_order_transactions_fails_with_cyclic_tx(
 
 def test_order_transactions_fails_with_multiple_starts(
         bdb_driver, alice_keypair, bob_keypair, carly_keypair):
-    from coalaip_bigchaindb.utils import order_transactions
+    from coalaip_bigchaindb.utils import make_transfer_tx, order_transactions
     create_tx_alice = bdb_driver.transactions.prepare(
         operation='CREATE',
         signers=alice_keypair['public_key'])
@@ -143,7 +159,7 @@ def test_order_transactions_fails_with_multiple_starts(
 
 def test_order_transactions_fails_with_missing_tx(bdb_driver, alice_keypair,
                                                   bob_keypair, carly_keypair):
-    from coalaip_bigchaindb.utils import order_transactions
+    from coalaip_bigchaindb.utils import make_transfer_tx, order_transactions
     create_tx = bdb_driver.transactions.prepare(
         operation='CREATE',
         signers=alice_keypair['public_key'])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,23 +3,6 @@ from time import sleep
 from pytest import fail
 
 
-def make_transfer_tx(bdb_driver, *, input_tx, recipients):
-    input_tx_id = input_tx['id'] if input_tx['operation'] == 'CREATE' else input_tx['asset']['id']  # noqa
-    input_tx_output = input_tx['outputs'][0]
-    return bdb_driver.transactions.prepare(
-        operation='TRANSFER',
-        recipients=recipients,
-        asset={'id': input_tx_id},
-        inputs={
-            'fulfillment': input_tx_output['condition']['details'],
-            'fulfills': {
-                'output': 0,
-                'txid': input_tx['id'],
-            },
-            'owners_before': input_tx_output['public_keys']
-        })
-
-
 def poll_bdb_transaction_valid(driver, tx_id):
     return poll_result(
         lambda: driver.transactions.status(tx_id),


### PR DESCRIPTION
Fixes #10.

Builds on #37.

**Note**: Something I noticed while doing this was that `status()` doesn't really make sense anymore; originally it was meant to get the status for a single event / transaction, but now there can be multiple transactions linked to an entity. I feel like it's not really useful anymore -- you can see what the current owner of the entity is with `.current_owner` instead. Thoughts?