### PR TITLE
Refactor tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -98,13 +98,11 @@ def created_manifestation_id(created_manifestation):
 
 @fixture
 def persisted_manifestation(bdb_driver, created_manifestation):
-    from tests.utils import bdb_transaction_test, poll_result
+    from tests.utils import poll_bdb_transaction_valid
     tx_id = created_manifestation['id']
 
     # Poll BigchainDB until the created manifestation becomes valid (and
     # 'persisted')
-    poll_result(
-        lambda: bdb_driver.transactions.status(tx_id),
-        lambda result: bdb_transaction_test)
+    poll_bdb_transaction_valid(bdb_driver, tx_id)
 
     return created_manifestation

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,39 +4,15 @@ from pytest import fixture
 
 
 @fixture
-def alice_private_key():
-    return 'CT6nWhSyE7dF2znpx3vwXuceSrmeMy9ChBfi9U92HMSP'
+def alice_keypair():
+    from bigchaindb_driver.crypto import generate_keypair
+    return generate_keypair()._asdict()
 
 
 @fixture
-def alice_public_key():
-    return 'G7J7bXF8cqSrjrxUKwcF8tCriEKC5CgyPHmtGwUi4BK3'
-
-
-@fixture
-def alice_keypair(alice_private_key, alice_public_key):
-    return {
-        'private_key': alice_private_key,
-        'public_key': alice_public_key
-    }
-
-
-@fixture
-def bob_private_key():
-    return '4S1dzx3PSdMAfs59aBkQefPASizTs728HnhLNpYZWCad'
-
-
-@fixture
-def bob_public_key():
-    return '2dBVUoATxEzEqRdsi64AFsJnn2ywLCwnbNwW7K9BuVuS'
-
-
-@fixture
-def bob_keypair(bob_private_key, bob_public_key):
-    return {
-        'private_key': bob_private_key,
-        'public_key': bob_public_key
-    }
+def bob_keypair():
+    from bigchaindb_driver.crypto import generate_keypair
+    return generate_keypair()._asdict()
 
 
 @fixture

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -92,14 +92,19 @@ def created_manifestation(bdb_driver, manifestation_model_jsonld,
 
 
 @fixture
+def created_manifestation_id(created_manifestation):
+    return created_manifestation['id']
+
+
+@fixture
 def persisted_manifestation(bdb_driver, created_manifestation):
     from tests.utils import bdb_transaction_test, poll_result
-    created_id = created_manifestation['id']
+    tx_id = created_manifestation['id']
 
     # Poll BigchainDB until the created manifestation becomes valid (and
     # 'persisted')
     poll_result(
-        lambda: bdb_driver.transactions.status(created_id),
+        lambda: bdb_driver.transactions.status(tx_id),
         lambda result: bdb_transaction_test)
 
     return created_manifestation

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -149,49 +149,47 @@ def test_transfer(plugin, bdb_driver, persisted_manifestation, model_name,
 # Generic NotFoundError tests #
 ###############################
 
-def test_get_status_raises_not_found_error_on_not_found(monkeypatch, plugin,
-                                                        created_manifestation_id):
+@mark.parametrize('func_name,driver_tx_func_name', [
+    ('get_status', 'status'),
+    ('load', 'retrieve')
+])
+def test_generic_plugin_func_on_id_raises_not_found_error_on_not_found(
+        monkeypatch, plugin, created_manifestation_id, func_name,
+        driver_tx_func_name):
     from bigchaindb_driver.exceptions import NotFoundError
     from coalaip.exceptions import EntityNotFoundError
+    plugin_func = getattr(plugin, func_name)
 
     def mock_driver_not_found_error(*args, **kwargs):
         raise NotFoundError()
-    monkeypatch.setattr(plugin.driver.transactions, 'status',
+    monkeypatch.setattr(plugin.driver.transactions, driver_tx_func_name,
                         mock_driver_not_found_error)
 
     with raises(EntityNotFoundError):
-        plugin.get_status(created_manifestation_id)
-
-
-def test_load_model_raises_not_found_error_on_not_found(
-        monkeypatch, plugin, created_manifestation_id):
-    from bigchaindb_driver.exceptions import NotFoundError
-    from coalaip.exceptions import EntityNotFoundError
-
-    def mock_driver_not_found_error(*args, **kwargs):
-        raise NotFoundError()
-    monkeypatch.setattr(plugin.driver.transactions, 'retrieve',
-                        mock_driver_not_found_error)
-
-    with raises(EntityNotFoundError):
-        plugin.load(created_manifestation_id)
+        plugin_func(created_manifestation_id)
 
 
 ##################################
 # Generic PersistenceError tests #
 ##################################
 
-def test_get_status_raises_persistence_error_on_error(monkeypatch, plugin,
-                                                      created_manifestation_id):
+@mark.parametrize('func_name,driver_tx_func_name', [
+    ('get_status', 'status'),
+    ('load', 'retrieve')
+])
+def test_generic_plugin_func_on_id_raises_persistence_error_on_error(
+        monkeypatch, plugin, created_manifestation_id, func_name,
+        driver_tx_func_name):
     from coalaip.exceptions import PersistenceError
+    plugin_func = getattr(plugin, func_name)
 
-    def mock_driver_error(*args, **kwargs):
+    def mock_driver_not_found_error(*args, **kwargs):
         raise Exception()
-    monkeypatch.setattr(plugin.driver.transactions, 'status',
-                        mock_driver_error)
+    monkeypatch.setattr(plugin.driver.transactions, driver_tx_func_name,
+                        mock_driver_not_found_error)
 
     with raises(PersistenceError):
-        plugin.get_status(created_manifestation_id)
+        plugin_func(created_manifestation_id)
 
 
 def test_save_raises_persistence_error_on_error(monkeypatch, plugin,
@@ -210,16 +208,3 @@ def test_save_raises_persistence_error_on_error(monkeypatch, plugin,
 
     with raises(PersistenceError):
         plugin.save(manifestation_model_json, user=alice_keypair)
-
-
-def test_load_model_raises_persistence_error_on_error(monkeypatch, plugin,
-                                                      created_manifestation_id):
-    from coalaip.exceptions import PersistenceError
-
-    def mock_driver_error(*args, **kwargs):
-        raise Exception()
-    monkeypatch.setattr(plugin.driver.transactions, 'retrieve',
-                        mock_driver_error)
-
-    with raises(PersistenceError):
-        plugin.load(created_manifestation_id)

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -19,12 +19,10 @@ def test_generate_user(plugin):
     assert isinstance(user['private_key'], str)
 
 
-def test_get_status(plugin, created_manifestation):
-    tx_id = created_manifestation['id']
-
+def test_get_status(plugin, created_manifestation_id):
     # Poll BigchainDB for the initial status
     poll_result(
-        lambda: plugin.get_status(tx_id),
+        lambda: plugin.get_status(created_manifestation_id),
         lambda result: result['status'] in (
             'valid', 'invalid', 'undecided', 'backlog'))
 
@@ -32,12 +30,12 @@ def test_get_status(plugin, created_manifestation):
     # transaction's status doesn't become valid by the end of the timeout
     # period.
     poll_result(
-        lambda: plugin.get_status(tx_id),
+        lambda: plugin.get_status(created_manifestation_id),
         lambda result: result['status'] == 'valid')
 
 
 def test_get_status_raises_not_found_error_on_not_found(monkeypatch, plugin,
-                                                        created_manifestation):
+                                                        created_manifestation_id):
     from bigchaindb_driver.exceptions import NotFoundError
     from coalaip.exceptions import EntityNotFoundError
 
@@ -47,11 +45,11 @@ def test_get_status_raises_not_found_error_on_not_found(monkeypatch, plugin,
                         mock_driver_not_found_error)
 
     with raises(EntityNotFoundError):
-        plugin.get_status(created_manifestation['id'])
+        plugin.get_status(created_manifestation_id)
 
 
 def test_get_status_raises_persistence_error_on_error(monkeypatch, plugin,
-                                                      created_manifestation):
+                                                      created_manifestation_id):
     from coalaip.exceptions import PersistenceError
 
     def mock_driver_error(*args, **kwargs):
@@ -60,7 +58,7 @@ def test_get_status_raises_persistence_error_on_error(monkeypatch, plugin,
                         mock_driver_error)
 
     with raises(PersistenceError):
-        plugin.get_status(created_manifestation['id'])
+        plugin.get_status(created_manifestation_id)
 
 
 @mark.parametrize('model_name', [
@@ -165,7 +163,7 @@ def test_load_model(plugin, persisted_manifestation):
 
 
 def test_load_model_raises_not_found_error_on_not_found(
-        monkeypatch, plugin, created_manifestation):
+        monkeypatch, plugin, created_manifestation_id):
     from bigchaindb_driver.exceptions import NotFoundError
     from coalaip.exceptions import EntityNotFoundError
 
@@ -175,11 +173,11 @@ def test_load_model_raises_not_found_error_on_not_found(
                         mock_driver_not_found_error)
 
     with raises(EntityNotFoundError):
-        plugin.load(created_manifestation['id'])
+        plugin.load(created_manifestation_id)
 
 
 def test_load_model_raises_persistence_error_on_error(monkeypatch, plugin,
-                                                      created_manifestation):
+                                                      created_manifestation_id):
     from coalaip.exceptions import PersistenceError
 
     def mock_driver_error(*args, **kwargs):
@@ -188,7 +186,7 @@ def test_load_model_raises_persistence_error_on_error(monkeypatch, plugin,
                         mock_driver_error)
 
     with raises(PersistenceError):
-        plugin.load(created_manifestation['id'])
+        plugin.load(created_manifestation_id)
 
 
 @mark.skip(reason='transfer() not implemented yet')

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 
 from pytest import mark, raises
-from tests.utils import bdb_transaction_test, poll_result
+from tests.utils import (
+    poll_bdb_transaction,
+    poll_result,
+)
 
 
 def test_plugin_type_is_bigchaindb(plugin):
@@ -43,9 +46,7 @@ def test_save_model(plugin, bdb_driver, model_name, alice_keypair, request):
     tx_id = plugin.save(model_data, user=alice_keypair)
 
     # Poll BigchainDB for the result
-    tx = poll_result(
-        lambda: bdb_driver.transactions.retrieve(tx_id),
-        bdb_transaction_test)
+    tx = poll_bdb_transaction(bdb_driver, tx_id)
 
     tx_payload = tx['asset']['data']
     tx_new_owners = tx['outputs'][0]['public_keys']
@@ -132,9 +133,7 @@ def test_transfer(plugin, bdb_driver, persisted_manifestation, model_name,
                                      to_user=bob_keypair)
 
     # Poll BigchainDB for the result
-    transfer_tx = poll_result(
-        lambda: bdb_driver.transactions.retrieve(transfer_tx_id),
-        bdb_transaction_test)
+    transfer_tx = poll_bdb_transaction(bdb_driver, transfer_tx_id)
 
     transfer_tx_fulfillments = transfer_tx['inputs']
     transfer_tx_conditions = transfer_tx['outputs']

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -34,33 +34,6 @@ def test_get_status(plugin, created_manifestation_id):
         lambda result: result['status'] == 'valid')
 
 
-def test_get_status_raises_not_found_error_on_not_found(monkeypatch, plugin,
-                                                        created_manifestation_id):
-    from bigchaindb_driver.exceptions import NotFoundError
-    from coalaip.exceptions import EntityNotFoundError
-
-    def mock_driver_not_found_error(*args, **kwargs):
-        raise NotFoundError()
-    monkeypatch.setattr(plugin.driver.transactions, 'status',
-                        mock_driver_not_found_error)
-
-    with raises(EntityNotFoundError):
-        plugin.get_status(created_manifestation_id)
-
-
-def test_get_status_raises_persistence_error_on_error(monkeypatch, plugin,
-                                                      created_manifestation_id):
-    from coalaip.exceptions import PersistenceError
-
-    def mock_driver_error(*args, **kwargs):
-        raise Exception()
-    monkeypatch.setattr(plugin.driver.transactions, 'status',
-                        mock_driver_error)
-
-    with raises(PersistenceError):
-        plugin.get_status(created_manifestation_id)
-
-
 @mark.parametrize('model_name', [
     'manifestation_model_jsonld',
     'manifestation_model_json'
@@ -110,24 +83,6 @@ def test_save_raises_entity_creation_error_on_missing_key(monkeypatch, plugin,
         plugin.save(manifestation_model_json, user=alice_keypair)
 
 
-def test_save_raises_persistence_error_on_error(monkeypatch, plugin,
-                                                manifestation_model_json,
-                                                alice_keypair):
-    """If bigchaindb-driver returns an error not caught in
-    pycoalaip-bigchaindb, convert it into a
-    `~coalaip.exceptions.PersistenceError`.
-    """
-    from coalaip.exceptions import PersistenceError
-
-    def mock_driver_error(*args, **kwargs):
-        raise Exception()
-    monkeypatch.setattr(plugin.driver.transactions, 'prepare',
-                        mock_driver_error)
-
-    with raises(PersistenceError):
-        plugin.save(manifestation_model_json, user=alice_keypair)
-
-
 def test_save_raises_entity_creation_error_on_transport_error(
         monkeypatch, plugin, manifestation_model_json, alice_keypair):
     from bigchaindb_driver.exceptions import TransportError
@@ -162,33 +117,6 @@ def test_load_model(plugin, persisted_manifestation):
     assert loaded_transaction == persisted_manifestation['asset']['data']
 
 
-def test_load_model_raises_not_found_error_on_not_found(
-        monkeypatch, plugin, created_manifestation_id):
-    from bigchaindb_driver.exceptions import NotFoundError
-    from coalaip.exceptions import EntityNotFoundError
-
-    def mock_driver_not_found_error(*args, **kwargs):
-        raise NotFoundError()
-    monkeypatch.setattr(plugin.driver.transactions, 'retrieve',
-                        mock_driver_not_found_error)
-
-    with raises(EntityNotFoundError):
-        plugin.load(created_manifestation_id)
-
-
-def test_load_model_raises_persistence_error_on_error(monkeypatch, plugin,
-                                                      created_manifestation_id):
-    from coalaip.exceptions import PersistenceError
-
-    def mock_driver_error(*args, **kwargs):
-        raise Exception()
-    monkeypatch.setattr(plugin.driver.transactions, 'retrieve',
-                        mock_driver_error)
-
-    with raises(PersistenceError):
-        plugin.load(created_manifestation_id)
-
-
 @mark.skip(reason='transfer() not implemented yet')
 @mark.parametrize('model_name', [
     'rights_assignment_model_jsonld',
@@ -215,3 +143,83 @@ def test_transfer(plugin, bdb_driver, persisted_manifestation, model_name,
     assert transfer_tx['id'] == tx_id
     assert transfer_tx_prev_owners[0] == alice_keypair['public_key']
     assert transfer_tx_new_owners[0] == bob_keypair['public_key']
+
+
+###############################
+# Generic NotFoundError tests #
+###############################
+
+def test_get_status_raises_not_found_error_on_not_found(monkeypatch, plugin,
+                                                        created_manifestation_id):
+    from bigchaindb_driver.exceptions import NotFoundError
+    from coalaip.exceptions import EntityNotFoundError
+
+    def mock_driver_not_found_error(*args, **kwargs):
+        raise NotFoundError()
+    monkeypatch.setattr(plugin.driver.transactions, 'status',
+                        mock_driver_not_found_error)
+
+    with raises(EntityNotFoundError):
+        plugin.get_status(created_manifestation_id)
+
+
+def test_load_model_raises_not_found_error_on_not_found(
+        monkeypatch, plugin, created_manifestation_id):
+    from bigchaindb_driver.exceptions import NotFoundError
+    from coalaip.exceptions import EntityNotFoundError
+
+    def mock_driver_not_found_error(*args, **kwargs):
+        raise NotFoundError()
+    monkeypatch.setattr(plugin.driver.transactions, 'retrieve',
+                        mock_driver_not_found_error)
+
+    with raises(EntityNotFoundError):
+        plugin.load(created_manifestation_id)
+
+
+##################################
+# Generic PersistenceError tests #
+##################################
+
+def test_get_status_raises_persistence_error_on_error(monkeypatch, plugin,
+                                                      created_manifestation_id):
+    from coalaip.exceptions import PersistenceError
+
+    def mock_driver_error(*args, **kwargs):
+        raise Exception()
+    monkeypatch.setattr(plugin.driver.transactions, 'status',
+                        mock_driver_error)
+
+    with raises(PersistenceError):
+        plugin.get_status(created_manifestation_id)
+
+
+def test_save_raises_persistence_error_on_error(monkeypatch, plugin,
+                                                manifestation_model_json,
+                                                alice_keypair):
+    """If bigchaindb-driver returns an error not caught in
+    pycoalaip-bigchaindb, convert it into a
+    `~coalaip.exceptions.PersistenceError`.
+    """
+    from coalaip.exceptions import PersistenceError
+
+    def mock_driver_error(*args, **kwargs):
+        raise Exception()
+    monkeypatch.setattr(plugin.driver.transactions, 'prepare',
+                        mock_driver_error)
+
+    with raises(PersistenceError):
+        plugin.save(manifestation_model_json, user=alice_keypair)
+
+
+def test_load_model_raises_persistence_error_on_error(monkeypatch, plugin,
+                                                      created_manifestation_id):
+    from coalaip.exceptions import PersistenceError
+
+    def mock_driver_error(*args, **kwargs):
+        raise Exception()
+    monkeypatch.setattr(plugin.driver.transactions, 'retrieve',
+                        mock_driver_error)
+
+    with raises(PersistenceError):
+        plugin.load(created_manifestation_id)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,19 @@ from time import sleep
 from pytest import fail
 
 
+def poll_bdb_transaction_valid(driver, tx_id):
+    return poll_result(
+        lambda: driver.transactions.status(tx_id),
+        lambda result: result.get('status') == 'valid')
+
+
+def poll_bdb_transaction(driver, tx_id):
+    return poll_result(
+        lambda: driver.transactions.retrieve(tx_id),
+        # If the retrieve fails, a message with a 404 status will be returned
+        lambda result: result.get('status') != 404 and result.get('id'))
+
+
 def poll_result(fn, result_test_fn, *, max_checks=5, interval=1):
     """Polling utility for cases where we need to wait for BigchainDB
     processing. After 'max_checks' attempts, will fail the test with the
@@ -31,7 +44,3 @@ def poll_result(fn, result_test_fn, *, max_checks=5, interval=1):
         sleep(interval)
 
     fail("Polling result failed with result: '{}'".format(result))
-
-
-def bdb_transaction_test(tx_result):
-    return tx_result.get('status') != 404 and tx_result.get('id')


### PR DESCRIPTION
Small refactoring for tests. Making the keypairs unique is useful so that we don't end up pushing the same transactions (and having them discarded by the server) on each test function and run.