### PR TITLE
Add ability to get ordered tx history of an entity

### DIFF
--- a/coalaip_bigchaindb/utils.py
+++ b/coalaip_bigchaindb/utils.py
@@ -58,9 +58,12 @@ def order_transactions(transactions):
         if tx['id'] not in input_dependencies:
             if end_tx:
                 raise ValueError(
-                    ('Two potential ending transactions (with  ids: `{}` and '
-                     '`{}` were found when attempting to order a list of '
-                     'transactions.'.format(end_tx['id'], tx['id'])))
+                    ('More than one transaction (ids include `{}` and `{}`) '
+                     'was found to have no other transactions depend upon it '
+                     'when attempting to order a list of transactions. This '
+                     'means that the given list either contains a transaction '
+                     'chain that is not flat or that some transactions are '
+                     'missing from the list.'.format(end_tx['id'], tx['id'])))
             end_tx = tx
 
     if not end_tx:
@@ -76,21 +79,6 @@ def order_transactions(transactions):
 
         # If we're at the start of the tx chain, there is no next tx to find
         if ii is not 0:
-            fulfilled_by = end_tx['inputs'][0]['fulfills']
-            if not fulfilled_by:
-                raise ValueError(
-                    ('Found transaction with id `{}` that does not fulfill a '
-                     'prior transaction before an attempt to order a list of '
-                     'transactions was complete. There were most likely two '
-                     'CREATE transactions given.'.format(end_tx['id'])))
-            try:
-                end_tx = txs_by_id[fulfilled_by['txid']]
-            except KeyError:
-                raise ValueError(
-                    ('Could not find a transaction with with id `{input_tx}` '
-                     '(that transaction `{tx}` depends upon) when attempting '
-                     'to order a list of transatcions.'.format(
-                         input_tx=end_tx['inputs'][0]['fulfills']['txid'],
-                         tx=end_tx['id'])))
+            end_tx = txs_by_id[end_tx['inputs'][0]['fulfills']['txid']]
 
     return ordered_tx

--- a/coalaip_bigchaindb/utils.py
+++ b/coalaip_bigchaindb/utils.py
@@ -16,8 +16,81 @@ def reraise_as_persistence_error_if_not(*allowed_exceptions):
                 return func(*args, **kwargs)
             except Exception as ex:
                 if not isinstance(ex, allowed_exceptions):
-                    raise PersistenceError(error=ex)
+                    raise PersistenceError(error=ex) from ex
                 else:
                     raise
         return reraises_if_not
     return decorator
+
+
+def order_transactions(transactions):
+    """Given a list of unordered transactions, order and return them in
+    a new list.
+
+    Assumes that the given transactions never have more than one input
+    and output (and therefore, as well, that there is never any
+    transaction that divides assets); this allows us to represent the
+    ordered transactions as a list rather than a branching graph.
+
+    Args:
+        transactions (list): Unordered list of transactions
+
+    Returns:
+        list: Ordered list of transactions, beginning from the first
+        available transaction.
+
+    Raises:
+        :exc:`ValueError`: If the given list of transactions include two
+            or more disjoint chains (i.e. not linkable into a single
+            chain).
+    """
+    if not transactions:
+        return []
+
+    # Find the end tx:
+    #   Go through the transactions and find the transaction whose id is not
+    #   listed as a dependency of any other transaction
+    end_tx = None
+    input_dependencies = {tx['inputs'][0]['fulfills']['txid']
+                          for tx in transactions
+                          if tx['inputs'][0]['fulfills']}
+    for tx in transactions:
+        if tx['id'] not in input_dependencies:
+            if end_tx:
+                raise ValueError(
+                    ('Two potential ending transactions (with  ids: `{}` and '
+                     '`{}` were found when attempting to order a list of '
+                     'transactions.'.format(end_tx['id'], tx['id'])))
+            end_tx = tx
+
+    if not end_tx:
+        raise ValueError(('Could not find an end transaction when attempting '
+                          'to order a list of transactions. This most likely '
+                          'means the given list contains a cycle somewhere.'))
+
+    # Create the ordered list of transactions, going backwards from the end
+    ordered_tx = [None] * len(transactions)
+    txs_by_id = {tx['id']: tx for tx in transactions}
+    for ii in reversed(range(0, len(transactions))):
+        ordered_tx[ii] = end_tx
+
+        # If we're at the start of the tx chain, there is no next tx to find
+        if ii is not 0:
+            fulfilled_by = end_tx['inputs'][0]['fulfills']
+            if not fulfilled_by:
+                raise ValueError(
+                    ('Found transaction with id `{}` that does not fulfill a '
+                     'prior transaction before an attempt to order a list of '
+                     'transactions was complete. There were most likely two '
+                     'CREATE transactions given.'.format(end_tx['id'])))
+            try:
+                end_tx = txs_by_id[fulfilled_by['txid']]
+            except KeyError:
+                raise ValueError(
+                    ('Could not find a transaction with with id `{input_tx}` '
+                     '(that transaction `{tx}` depends upon) when attempting '
+                     'to order a list of transatcions.'.format(
+                         input_tx=end_tx['inputs'][0]['fulfills']['txid'],
+                         tx=end_tx['id'])))
+
+    return ordered_tx

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,12 @@ def bob_keypair():
 
 
 @fixture
+def carly_keypair():
+    from bigchaindb_driver.crypto import generate_keypair
+    return generate_keypair()._asdict()
+
+
+@fixture
 def bdb_host():
     return environ.get('BDB_HOST', 'localhost')
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 from pytest import raises
+from tests.utils import make_transfer_tx
 
 
 def test_reraise_as_persistence_error():
@@ -28,3 +29,136 @@ def test_reraise_as_persistence_error_raises_allowed():
     with raises(TypeError) as excinfo:
         raises_type_error()
     assert excinfo.value == mock_type_error
+
+
+def test_order_transactions(bdb_driver, alice_keypair, bob_keypair):
+    import random
+    from coalaip_bigchaindb.utils import order_transactions
+    create_tx = bdb_driver.transactions.prepare(
+        operation='CREATE',
+        signers=alice_keypair['public_key'])
+    transfer_to_bob_tx = make_transfer_tx(bdb_driver, input_tx=create_tx,
+                                          recipients=bob_keypair['public_key'])
+    transfer_back_to_alice_tx = make_transfer_tx(
+        bdb_driver, input_tx=transfer_to_bob_tx, recipients=alice_keypair['public_key'])
+
+    correct_order = [create_tx, transfer_to_bob_tx, transfer_back_to_alice_tx]
+    for _ in range(0, 100):
+        assert correct_order == order_transactions(
+            random.sample(correct_order, len(correct_order)))
+
+
+def test_order_transactions_is_correct_without_create(
+        bdb_driver, alice_keypair, bob_keypair):
+    import random
+    from coalaip_bigchaindb.utils import order_transactions
+    create_tx = bdb_driver.transactions.prepare(
+        operation='CREATE',
+        signers=alice_keypair['public_key'])
+    transfer_to_bob_tx = make_transfer_tx(bdb_driver, input_tx=create_tx,
+                                          recipients=bob_keypair['public_key'])
+    transfer_back_to_alice_tx = make_transfer_tx(
+        bdb_driver, input_tx=transfer_to_bob_tx, recipients=alice_keypair['public_key'])
+    transfer_back_to_bob_tx = make_transfer_tx(
+        bdb_driver, input_tx=transfer_back_to_alice_tx, recipients=bob_keypair['public_key'])
+
+    correct_order = [transfer_to_bob_tx, transfer_back_to_alice_tx, transfer_back_to_bob_tx]
+    for _ in range(0, 100):
+        assert correct_order == order_transactions(
+            random.sample(correct_order, len(correct_order)))
+
+
+def test_order_empty_transations():
+    from coalaip_bigchaindb.utils import order_transactions
+    ordered_tx = order_transactions([])
+    assert ordered_tx == []
+
+
+def test_order_transactions_fails_with_multiple_endings(
+        bdb_driver, alice_keypair, bob_keypair, carly_keypair):
+    from coalaip_bigchaindb.utils import order_transactions
+    create_tx = bdb_driver.transactions.prepare(
+        operation='CREATE',
+        signers=alice_keypair['public_key'])
+    transfer_to_bob_tx = make_transfer_tx(bdb_driver, input_tx=create_tx,
+                                          recipients=bob_keypair['public_key'])
+    transfer_to_carly_tx = make_transfer_tx(
+        bdb_driver, input_tx=create_tx, recipients=carly_keypair['public_key'])
+
+    with raises(ValueError):
+        # Transfer to both bob and carly should result in a multiple endings
+        # error
+        order_transactions([create_tx, transfer_to_bob_tx, transfer_to_carly_tx])
+
+
+def test_order_transactions_fails_with_cyclic_tx(
+        bdb_driver, alice_keypair, bob_keypair, carly_keypair):
+    from coalaip_bigchaindb.utils import order_transactions
+    create_tx = bdb_driver.transactions.prepare(
+        operation='CREATE',
+        signers=alice_keypair['public_key'])
+    transfer_to_bob_tx = make_transfer_tx(bdb_driver, input_tx=create_tx,
+                                          recipients=bob_keypair['public_key'])
+    transfer_to_carly_tx = make_transfer_tx(
+        bdb_driver, input_tx=transfer_to_bob_tx, recipients=carly_keypair['public_key'])
+    transfer_to_alice_tx = make_transfer_tx(
+        bdb_driver, input_tx=transfer_to_carly_tx, recipients=alice_keypair['public_key'])
+
+    # Modify transfer to bob tx so that it links back to the transfer to alice.
+    # This should create a
+    #   bob_transfer <- carly_transfer <- alice_transfer <- bob_transfer
+    # dependency cycle.
+    transfer_to_bob_tx['inputs'][0]['fulfills']['txid'] = transfer_to_alice_tx['id']
+
+    with raises(ValueError):
+        order_transactions([
+            transfer_to_bob_tx,
+            transfer_to_carly_tx,
+            transfer_to_alice_tx,
+        ])
+
+
+def test_order_transactions_fails_with_multiple_starts(
+        bdb_driver, alice_keypair, bob_keypair, carly_keypair):
+    from coalaip_bigchaindb.utils import order_transactions
+    create_tx_alice = bdb_driver.transactions.prepare(
+        operation='CREATE',
+        signers=alice_keypair['public_key'])
+    create_tx_bob = bdb_driver.transactions.prepare(
+        operation='CREATE',
+        signers=bob_keypair['public_key'])
+    transfer_to_carly_tx = make_transfer_tx(
+        bdb_driver, input_tx=create_tx_alice,
+        recipients=carly_keypair['public_key'])
+
+    with raises(ValueError):
+        # Multiple CREATEs should result in an error with multiple tx not
+        # fulfilling a prior tx
+        order_transactions([
+            create_tx_alice,
+            create_tx_bob,
+            transfer_to_carly_tx,
+        ])
+
+
+def test_order_transactions_fails_with_missing_tx(bdb_driver, alice_keypair,
+                                                  bob_keypair, carly_keypair):
+    from coalaip_bigchaindb.utils import order_transactions
+    create_tx = bdb_driver.transactions.prepare(
+        operation='CREATE',
+        signers=alice_keypair['public_key'])
+    transfer_to_bob_tx = make_transfer_tx(bdb_driver, input_tx=create_tx,
+                                          recipients=bob_keypair['public_key'])
+    transfer_to_carly_tx = make_transfer_tx(
+        bdb_driver, input_tx=transfer_to_bob_tx, recipients=carly_keypair['public_key'])
+    transfer_to_alice_tx = make_transfer_tx(
+        bdb_driver, input_tx=transfer_to_carly_tx, recipients=alice_keypair['public_key'])
+
+    with raises(ValueError):
+        # Missing transfer to carly (that the transfer to alice is based on)
+        # should result in an error with an unfound tx
+        order_transactions([
+            create_tx,
+            transfer_to_bob_tx,
+            transfer_to_alice_tx,
+        ])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,6 +3,23 @@ from time import sleep
 from pytest import fail
 
 
+def make_transfer_tx(bdb_driver, *, input_tx, recipients):
+    input_tx_id = input_tx['id'] if input_tx['operation'] == 'CREATE' else input_tx['asset']['id']  # noqa
+    input_tx_output = input_tx['outputs'][0]
+    return bdb_driver.transactions.prepare(
+        operation='TRANSFER',
+        recipients=recipients,
+        asset={'id': input_tx_id},
+        inputs={
+            'fulfillment': input_tx_output['condition']['details'],
+            'fulfills': {
+                'output': 0,
+                'txid': input_tx['id'],
+            },
+            'owners_before': input_tx_output['public_keys']
+        })
+
+
 def poll_bdb_transaction_valid(driver, tx_id):
     return poll_result(
         lambda: driver.transactions.status(tx_id),


### PR DESCRIPTION
Implements entity histories through the `api/v1/transactions?asset_id` API.

As the API may not necessarily return a *correct* chain of transactions, we post process the list given back to order them properly.